### PR TITLE
Fixed font file naming to prevent clashes.

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -162,7 +162,7 @@ module.exports = function(grunt) {
                 var fontWeight = rule.declarations['font-weight'];
                 var fontUrl = rule.declarations.src.match(/url\((.+?)\)/)[1];
                 var fontFormat = rule.declarations.src.match(/format\(\'(.+?)\'\)/);
-                var fontFile = fontOptions.family.replace(/\s+/, '-').toLowerCase() + '-' + fontWeight + '.' + format;
+                var fontFile = fontOptions.family.replace(/\s+/, '-').toLowerCase() + '-' + fontWeight + '-' + fontStyle + '.' + format;
                 var fontNameLocal = rule.declarations.src.match(/local\(\'(.+?)\'\)/g);
 
                 if (fontNameLocal !== null) {


### PR DESCRIPTION
Hey there!

I installed your package today and had some problems with some fonts. It seems the naming scheme you chose for the font files caused clashes when you had both a regular and an italic style with the same font weight, i.e.
```
styles: [400, '400italic']
```

I fixed the relevant piece of code. I didn't bump the version. Didn't want to mess with your versioning scheme.

Cheers!